### PR TITLE
fix: support GMS-backed target app location spoofing

### DIFF
--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/hooks/LocationApiHooks.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/hooks/LocationApiHooks.kt
@@ -136,48 +136,49 @@ class LocationApiHooks(val appLpparam: LoadPackageParam) {
                     }
                 })
 
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-                XposedHelpers.findAndHookMethod(
-                    locationClass,
-                    "getMslAltitudeMeters",
-                    object : XC_MethodHook() {
-                        override fun afterHookedMethod(param: MethodHookParam) {
-                            if (!shouldSpoofCurrentPackage()) return
-                            LocationUtil.updateLocation()
-                            XposedBridge.log("$tag Leaving method getMslAltitudeMeters()")
-                            val originalMslAltitude = param.result as? Double
-                            XposedBridge.log("\tOriginal MSL altitude: $originalMslAltitude")
-                            if (PreferencesUtil.getUseMeanSeaLevel() == true) {
-                                param.result = LocationUtil.meanSeaLevel
-                                XposedBridge.log("\tModified to: ${LocationUtil.meanSeaLevel}")
-                            }
-                        }
-                    })
+            hookOptionalLocationMethod(locationClass, "getMslAltitudeMeters", object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    if (!shouldSpoofCurrentPackage()) return
+                    LocationUtil.updateLocation()
+                    XposedBridge.log("$tag Leaving method getMslAltitudeMeters()")
+                    val originalMslAltitude = param.result as? Double
+                    XposedBridge.log("\tOriginal MSL altitude: $originalMslAltitude")
+                    if (PreferencesUtil.getUseMeanSeaLevel() == true) {
+                        param.result = LocationUtil.meanSeaLevel
+                        XposedBridge.log("\tModified to: ${LocationUtil.meanSeaLevel}")
+                    }
+                }
+            })
 
-                // Hook getMslAltitudeAccuracyMeters()
-                XposedHelpers.findAndHookMethod(
-                    locationClass,
-                    "getMslAltitudeAccuracyMeters",
-                    object : XC_MethodHook() {
-                        override fun afterHookedMethod(param: MethodHookParam) {
-                            if (!shouldSpoofCurrentPackage()) return
-                            LocationUtil.updateLocation()
-                            XposedBridge.log("$tag Leaving method getMslAltitudeAccuracyMeters()")
-                            val originalMslAltitudeAccuracy = param.result as? Float
-                            XposedBridge.log("\tOriginal MSL altitude accuracy: $originalMslAltitudeAccuracy")
-                            if (PreferencesUtil.getUseMeanSeaLevelAccuracy() == true) {
-                                param.result = LocationUtil.meanSeaLevelAccuracy
-                                XposedBridge.log("\tModified to: ${LocationUtil.meanSeaLevelAccuracy}")
-                            }
-                        }
-                    })
-            } else {
-                XposedBridge.log("$tag getMslAltitudeMeters() and getMslAltitudeAccuracyMeters() not available on this API level")
-            }
+            hookOptionalLocationMethod(locationClass, "getMslAltitudeAccuracyMeters", object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    if (!shouldSpoofCurrentPackage()) return
+                    LocationUtil.updateLocation()
+                    XposedBridge.log("$tag Leaving method getMslAltitudeAccuracyMeters()")
+                    val originalMslAltitudeAccuracy = param.result as? Float
+                    XposedBridge.log("\tOriginal MSL altitude accuracy: $originalMslAltitudeAccuracy")
+                    if (PreferencesUtil.getUseMeanSeaLevelAccuracy() == true) {
+                        param.result = LocationUtil.meanSeaLevelAccuracy
+                        XposedBridge.log("\tModified to: ${LocationUtil.meanSeaLevelAccuracy}")
+                    }
+                }
+            })
 
         } catch (e: Exception) {
             XposedBridge.log("$tag Error hooking Location class - ${e.message}")
         }
+    }
+
+    private fun hookOptionalLocationMethod(
+        locationClass: Class<*>,
+        methodName: String,
+        callback: XC_MethodHook
+    ) {
+        val methodExists = locationClass.methods.any { it.name == methodName && it.parameterTypes.isEmpty() } ||
+            locationClass.declaredMethods.any { it.name == methodName && it.parameterTypes.isEmpty() }
+        if (!methodExists) return
+
+        XposedHelpers.findAndHookMethod(locationClass, methodName, callback)
     }
 
     private fun hookLocationManager(classLoader: ClassLoader) {

--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/hooks/SystemServicesHooks.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/hooks/SystemServicesHooks.kt
@@ -22,6 +22,7 @@ class SystemServicesHooks(val appLpparam: LoadPackageParam) {
     fun initHooks() {
         val classLoader = appLpparam.classLoader
         hookLastLocation(classLoader)
+        hookCurrentLocation(classLoader)
         hookLocationDispatch(classLoader)
         hookMiuiLocationServices(classLoader)
         hookWifiServices(classLoader)
@@ -44,6 +45,23 @@ class SystemServicesHooks(val appLpparam: LoadPackageParam) {
                 val original = param.result as? Location
                 param.result = LocationUtil.createFakeLocation(original)
                 XposedBridge.log("$tag Replaced getLastLocation result.")
+            }
+        })
+    }
+
+    private fun hookCurrentLocation(classLoader: ClassLoader) {
+        val serviceClass = findClass(
+            classLoader,
+            "com.android.server.location.LocationManagerService",
+            "com.android.server.LocationManagerService"
+        ) ?: return
+
+        hookAll(serviceClass, "getCurrentLocation", object : XC_MethodHook() {
+            override fun beforeHookedMethod(param: MethodHookParam) {
+                if (!shouldSpoofArgs(param.args)) return
+
+                param.result = defaultReturnValue(param.method as? Method)
+                XposedBridge.log("$tag Blocked getCurrentLocation request for spoofed target.")
             }
         })
     }
@@ -77,11 +95,12 @@ class SystemServicesHooks(val appLpparam: LoadPackageParam) {
 
                 registrations.forEach { (key, value) ->
                     originalRegistrations[key] = value
-                    val packageName = extractPackageName(value)
-                    if (LocationUtil.shouldSpoofPackage(packageName)) {
+                    val packageNames = collectPackageNames(value)
+                    val spoofedPackage = packageNames.firstOrNull(LocationUtil::shouldSpoofPackage)
+                    if (spoofedPackage != null) {
                         locationsField.set(locationResult, arrayListOf(fakeLocation))
                         deliverLocationToRegistration(value, locationResult)
-                        XposedBridge.log("$tag Delivered spoofed provider location to $packageName.")
+                        XposedBridge.log("$tag Delivered spoofed provider location to $spoofedPackage.")
                     } else {
                         passthroughRegistrations[key] = value
                     }
@@ -156,7 +175,7 @@ class SystemServicesHooks(val appLpparam: LoadPackageParam) {
 
         hookAll(receiverClass, "callLocationChangedLocked", object : XC_MethodHook() {
             override fun beforeHookedMethod(param: MethodHookParam) {
-                if (!LocationUtil.shouldSpoofPackage(extractPackageName(param.thisObject))) return
+                if (collectPackageNames(param.thisObject).none(LocationUtil::shouldSpoofPackage)) return
 
                 val locationArgIndex = param.args.indexOfFirst { it is Location }
                 if (locationArgIndex == -1) return
@@ -333,25 +352,127 @@ class SystemServicesHooks(val appLpparam: LoadPackageParam) {
 
     private fun shouldSpoofArgs(args: Array<Any?>?): Boolean {
         return args?.asSequence()
-            ?.mapNotNull(::extractPackageName)
+            ?.flatMap { collectPackageNames(it).asSequence() }
+            ?.distinct()
             ?.any(LocationUtil::shouldSpoofPackage) == true
     }
 
-    private fun extractPackageName(value: Any?): String? {
-        if (value == null) return null
-        if (value is String) return value.takeIf(::looksLikePackageName)
+    private fun collectPackageNames(value: Any?): Set<String> {
+        return collectPackageNames(value, mutableSetOf(), 0)
+    }
 
-        listOf("mPackageName", "packageName", "callingPackage", "mCallingPackage").forEach { fieldName ->
+    private fun collectPackageNames(value: Any?, visited: MutableSet<Int>, depth: Int): Set<String> {
+        if (value == null || depth > 5) return emptySet()
+        if (value is String) return setOfNotNull(value.takeIf(::looksLikePackageName))
+
+        val identity = System.identityHashCode(value)
+        if (!visited.add(identity)) return emptySet()
+
+        val packageNames = linkedSetOf<String>()
+
+        if (value is Iterable<*>) {
+            value.forEach { packageNames += collectPackageNames(it, visited, depth + 1) }
+            return packageNames
+        }
+
+        if (value is Map<*, *>) {
+            value.forEach { (key, mapValue) ->
+                packageNames += collectPackageNames(key, visited, depth + 1)
+                packageNames += collectPackageNames(mapValue, visited, depth + 1)
+            }
+            return packageNames
+        }
+
+        packageNames += collectWorkSourcePackageNames(value)
+
+        listOf(
+            "mPackageName",
+            "packageName",
+            "callingPackage",
+            "mCallingPackage",
+            "mCallerPackageName",
+            "callerPackageName",
+            "mOpPackageName",
+            "opPackageName"
+        ).forEach { fieldName ->
             val packageName = findField(value.javaClass, fieldName)?.get(value) as? String
-            if (looksLikePackageName(packageName)) return packageName
+            packageName?.takeIf(::looksLikePackageName)?.let(packageNames::add)
         }
 
-        listOf("mIdentity", "mCallerIdentity", "callerIdentity", "identity").forEach { fieldName ->
-            val packageName = extractPackageName(findField(value.javaClass, fieldName)?.get(value))
-            if (packageName != null) return packageName
+        listOf(
+            "getPackageName",
+            "getCallingPackage",
+            "getCallerPackageName",
+            "getOpPackageName"
+        ).forEach { methodName ->
+            val packageName = runCatching {
+                findMethod(value.javaClass, methodName)?.invoke(value) as? String
+            }.getOrNull()
+            packageName?.takeIf(::looksLikePackageName)?.let(packageNames::add)
         }
 
-        return null
+        listOf(
+            "mIdentity",
+            "mCallerIdentity",
+            "callerIdentity",
+            "identity",
+            "mCallingIdentity",
+            "callingIdentity",
+            "mAttributionSource",
+            "attributionSource",
+            "mNext",
+            "next",
+            "mWorkSource",
+            "workSource",
+            "mRequest",
+            "request",
+            "mLocationRequest",
+            "locationRequest"
+        ).forEach { fieldName ->
+            packageNames += collectPackageNames(findField(value.javaClass, fieldName)?.get(value), visited, depth + 1)
+        }
+
+        listOf("getAttributionSource", "getNext", "getWorkSource", "getLocationRequest").forEach { methodName ->
+            val nestedValue = runCatching {
+                findMethod(value.javaClass, methodName)?.invoke(value)
+            }.getOrNull()
+            packageNames += collectPackageNames(nestedValue, visited, depth + 1)
+        }
+
+        return packageNames
+    }
+
+    private fun collectWorkSourcePackageNames(value: Any): Set<String> {
+        if (value.javaClass.name != "android.os.WorkSource") return emptySet()
+
+        val packageNames = linkedSetOf<String>()
+        val size = runCatching {
+            findMethod(value.javaClass, "size")?.invoke(value) as? Int
+        }.getOrNull() ?: return emptySet()
+
+        repeat(size) { index ->
+            val name = runCatching {
+                findMethod(value.javaClass, "getName", Integer.TYPE)?.invoke(value, index) as? String
+            }.getOrNull()
+            name?.takeIf(::looksLikePackageName)?.let(packageNames::add)
+        }
+
+        return packageNames
+    }
+
+    private fun findMethod(clazz: Class<*>, methodName: String, vararg parameterTypes: Class<*>): Method? {
+        var currentClass: Class<*>? = clazz
+        while (currentClass != null) {
+            try {
+                return currentClass.getDeclaredMethod(methodName, *parameterTypes).apply { isAccessible = true }
+            } catch (_: NoSuchMethodException) {
+                currentClass = currentClass.superclass
+            }
+        }
+
+        return clazz.methods.firstOrNull {
+            it.name == methodName && it.parameterTypes.contentEquals(parameterTypes)
+        }?.apply { isAccessible = true }
     }
 
     private fun looksLikePackageName(value: String?): Boolean {

--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/utils/PreferencesUtil.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/utils/PreferencesUtil.kt
@@ -11,6 +11,11 @@ import de.robv.android.xposed.XposedBridge
 object PreferencesUtil {
     private const val TAG = "[PreferencesUtil]"
 
+    private val locationProxyPackages = setOf(
+        "com.android.location.fused",
+        "com.google.android.gms"
+    )
+
     private val preferences: XSharedPreferences = XSharedPreferences(MANAGER_APP_PACKAGE_NAME, SHARED_PREFS_FILE).apply {
         makeWorldReadable()
         reload()
@@ -105,7 +110,8 @@ object PreferencesUtil {
         if (getIsPlaying() != true || getLastClickedLocation() == null) return false
 
         val targetApps = getTargetApps()
-        return targetApps.contains(packageName)
+        return targetApps.contains(packageName) ||
+            (targetApps.isNotEmpty() && locationProxyPackages.contains(packageName))
     }
 
     private inline fun <reified T> getPreference(key: String): T? {


### PR DESCRIPTION
The new in-app target selection worked on the originally tested MIUI-style system path, but failed on ROMs where target apps receive location through Google Play services or fused location proxy processes.

This fixes the regression by resolving caller packages more broadly in system_server, covering CallerIdentity / AttributionSource / WorkSource paths, and treating GMS/Fused as location proxy callers when target apps are selected. It also avoids hooking MSL altitude APIs on ROMs that do not expose them.