### PR TITLE
Fix LocationApiHooks init timing for Vector/API101; warn against system_server scope

### DIFF
--- a/app/src/main/java/com/noobexon/xposedfakelocation/data/Constants.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/data/Constants.kt
@@ -49,6 +49,9 @@ const val KEY_ENABLE_SYSTEM_HOOKS = "enable_system_hooks"
 const val KEY_THEME_OPTION = "theme_option"
 
 // Packages added/removed from module scope when system-level hooks are toggled.
+// DO NOT add "system" (Vector's scope name for system_server): hooking
+// system_server here threw an uncaught exception when WeChat requested location,
+// crashing system_server and forcing an Android watchdog reboot of the whole device.
 val SYSTEM_HOOK_PACKAGES = listOf("android", "com.android.phone")
 
  // DEFAULT VALUES

--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/ModuleEntry.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/ModuleEntry.kt
@@ -24,6 +24,7 @@ class ModuleEntry : XposedModule() {
     private var locationApiHooks: LocationApiHooks? = null
     private var systemServicesHooks: SystemServicesHooks? = null
     private var phoneServicesHooks: PhoneServicesHooks? = null
+    private var locationApiHooksInitialized = false
 
     override fun onModuleLoaded(param: ModuleLoadedParam) {
         log(Log.INFO, TAG, "onModuleLoaded: ${param.processName}")
@@ -51,6 +52,7 @@ class ModuleEntry : XposedModule() {
             // skip LocationApiHooks so we don't fake com.android.phone's own location requests.
             phoneServicesHooks = PhoneServicesHooks(this, param.classLoader).also { it.initHooks() }
         } else {
+            initLocationApiHooks(param.classLoader)
             initHookingLogic(param)
         }
     }
@@ -82,8 +84,14 @@ class ModuleEntry : XposedModule() {
                 log(Log.ERROR, TAG, "Toast/context failed - ${e.message}")
             }
 
-            locationApiHooks = LocationApiHooks(this, param.classLoader).also { it.initHooks() }
+            initLocationApiHooks(param.classLoader)
             result
         }
+    }
+
+    private fun initLocationApiHooks(classLoader: ClassLoader) {
+        if (locationApiHooksInitialized) return
+        locationApiHooksInitialized = true
+        locationApiHooks = LocationApiHooks(this, classLoader).also { it.initHooks() }
     }
 }


### PR DESCRIPTION
## Summary
- `ModuleEntry`: initialize `LocationApiHooks` from `onPackageReady` (guarded by a `locationApiHooksInitialized` flag) instead of waiting for the target app's `Application.callApplicationOnCreate`. On Vector (JingMatrix/LSPosed fork, libxposed API 101) the later hook point can fire too late for some target processes, leaving early location requests unfaked.
- `Constants`: add a warning comment that `"system"` must never be added to `SYSTEM_HOOK_PACKAGES`. Vector names the `system_server` process scope `"system"` (instead of the conventional `"android"`), and enabling Xposed hooks (LocationManagerService/WifiServiceImpl/GNSS callbacks) inside `system_server` can throw uncaught exceptions there. That crashes `system_server`, and the Android watchdog responds by force-rebooting the entire device — not just the app.

## Why this matters
While migrating a device from LSPosed 1.11.0 (API 100) to Vector (API 101), I found that:
1. Without the timing fix, some apps' early location calls returned the real location instead of the faked one under Vector.
2. Adding `"system"` to the system-hook scope list (a reasonable-looking choice if you assume Vector names `system_server`'s scope like the framework's traditional `"android"`) caused the **entire device to reboot** every time WeChat requested location — a potential bootloop trap for anyone trying the same thing. The comment documents this so nobody else loses an evening recovering their phone.

## Test plan
- [x] Built and signed locally, installed over the existing app on a Vector (API 101) device (Android 16 / HyperOS-based, `shennong`).
- [x] Confirmed `LocationApiHooks` now initializes at `onPackageReady` and fake location is applied from app start (verified via module logs and in-app location checks in Google Maps / Amap).
- [x] Confirmed that *without* `"system"` in `SYSTEM_HOOK_PACKAGES` (current upstream default, now documented), location requests from WeChat no longer crash `system_server` / reboot the device, while fake-location functionality continues to work normally.