### PR TITLE
Add custom route playback

### DIFF
--- a/app/src/main/java/com/noobexon/xposedfakelocation/data/Constants.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/data/Constants.kt
@@ -48,6 +48,9 @@ const val KEY_ENABLE_SYSTEM_HOOKS = "enable_system_hooks"
 
 const val KEY_THEME_OPTION = "theme_option"
 
+const val KEY_ROUTE_WAYPOINTS = "route_waypoints"
+const val KEY_ROUTE_LOOP_ENABLED = "route_loop_enabled"
+
 // Packages added/removed from module scope when system-level hooks are toggled.
 val SYSTEM_HOOK_PACKAGES = listOf("android", "com.android.phone")
 
@@ -85,6 +88,8 @@ const val DEFAULT_ENABLE_SYSTEM_HOOKS = false
 
 const val DEFAULT_THEME_OPTION = ""
 
+const val DEFAULT_ROUTE_LOOP_ENABLED = false
+
 // MATH & PHYS
 const val PI = 3.14159265359
 const val RADIUS_EARTH = 6378137.0 // Approximately Earth's radius in meters
@@ -95,3 +100,6 @@ const val DEFAULT_MAP_ZOOM = 18.0
 const val WORLD_MAP_ZOOM = 2.0
 const val LOCATION_DETECTION_MAX_ATTEMPTS = 80
 const val LOCATION_DETECTION_DELAY_MS = 100L
+const val MAX_ROUTE_WAYPOINTS = 4
+const val ROUTE_TICK_INTERVAL_MS = 1000L
+const val DEFAULT_ROUTE_SPEED_MPS = 1.4f

--- a/app/src/main/java/com/noobexon/xposedfakelocation/data/model/RouteWaypoint.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/data/model/RouteWaypoint.kt
@@ -1,0 +1,6 @@
+package com.noobexon.xposedfakelocation.data.model
+
+data class RouteWaypoint(
+    val latitude: Double,
+    val longitude: Double
+)

--- a/app/src/main/java/com/noobexon/xposedfakelocation/data/repository/PrefrencesRepository.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/data/repository/PrefrencesRepository.kt
@@ -18,6 +18,7 @@ import com.noobexon.xposedfakelocation.data.DEFAULT_MAP_ZOOM
 import com.noobexon.xposedfakelocation.data.DEFAULT_MEAN_SEA_LEVEL
 import com.noobexon.xposedfakelocation.data.DEFAULT_MEAN_SEA_LEVEL_ACCURACY
 import com.noobexon.xposedfakelocation.data.DEFAULT_RANDOMIZE_RADIUS
+import com.noobexon.xposedfakelocation.data.DEFAULT_ROUTE_LOOP_ENABLED
 import com.noobexon.xposedfakelocation.data.DEFAULT_SPEED
 import com.noobexon.xposedfakelocation.data.DEFAULT_SPEED_ACCURACY
 import com.noobexon.xposedfakelocation.data.DEFAULT_THEME_OPTION
@@ -43,6 +44,8 @@ import com.noobexon.xposedfakelocation.data.KEY_MAP_ZOOM
 import com.noobexon.xposedfakelocation.data.KEY_MEAN_SEA_LEVEL
 import com.noobexon.xposedfakelocation.data.KEY_MEAN_SEA_LEVEL_ACCURACY
 import com.noobexon.xposedfakelocation.data.KEY_RANDOMIZE_RADIUS
+import com.noobexon.xposedfakelocation.data.KEY_ROUTE_LOOP_ENABLED
+import com.noobexon.xposedfakelocation.data.KEY_ROUTE_WAYPOINTS
 import com.noobexon.xposedfakelocation.data.KEY_SPEED
 import com.noobexon.xposedfakelocation.data.KEY_SPEED_ACCURACY
 import com.noobexon.xposedfakelocation.data.KEY_TARGET_APPS
@@ -60,6 +63,7 @@ import com.noobexon.xposedfakelocation.data.REMOTE_PREFS_GROUP
 import com.noobexon.xposedfakelocation.data.SHARED_PREFS_FILE
 import com.noobexon.xposedfakelocation.data.model.FavoriteLocation
 import com.noobexon.xposedfakelocation.data.model.LastClickedLocation
+import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
 import com.noobexon.xposedfakelocation.manager.App
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
@@ -340,6 +344,40 @@ class PreferencesRepository(context: Context) {
             emptyList()
         }
     }
+    // endregion
+
+    // region Route Waypoints (local)
+    fun getRouteWaypointsFlow(): Flow<List<RouteWaypoint>> =
+        localFlow(KEY_ROUTE_WAYPOINTS) { parseRouteWaypoints(it.getString(KEY_ROUTE_WAYPOINTS, null)) }
+
+    fun getRouteWaypoints(): List<RouteWaypoint> =
+        parseRouteWaypoints(localPrefs.getString(KEY_ROUTE_WAYPOINTS, null))
+
+    suspend fun saveRouteWaypoints(waypoints: List<RouteWaypoint>) {
+        val json = gson.toJson(waypoints)
+        editLocal { putString(KEY_ROUTE_WAYPOINTS, json) }
+    }
+
+    suspend fun clearRouteWaypoints() {
+        editLocal { remove(KEY_ROUTE_WAYPOINTS) }
+    }
+
+    private fun parseRouteWaypoints(json: String?): List<RouteWaypoint> {
+        if (json.isNullOrBlank()) return emptyList()
+        return try {
+            val type = object : TypeToken<List<RouteWaypoint>>() {}.type
+            gson.fromJson(json, type)
+        } catch (e: JsonSyntaxException) {
+            Log.e(tag, "Error parsing route waypoints: ${e.message}")
+            emptyList()
+        }
+    }
+
+    fun getRouteLoopEnabledFlow(): Flow<Boolean> =
+        localFlow(KEY_ROUTE_LOOP_ENABLED) { it.getBoolean(KEY_ROUTE_LOOP_ENABLED, DEFAULT_ROUTE_LOOP_ENABLED) }
+
+    suspend fun saveRouteLoopEnabled(enabled: Boolean) =
+        editLocal { putBoolean(KEY_ROUTE_LOOP_ENABLED, enabled) }
     // endregion
 
     // region Map Zoom (local)

--- a/app/src/main/java/com/noobexon/xposedfakelocation/data/repository/PrefrencesRepository.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/data/repository/PrefrencesRepository.kt
@@ -66,11 +66,15 @@ import com.noobexon.xposedfakelocation.data.model.LastClickedLocation
 import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
 import com.noobexon.xposedfakelocation.manager.App
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Single-source-of-truth preferences store.
@@ -79,7 +83,7 @@ import kotlinx.coroutines.flow.flowOf
  *  - Hook-shared settings (read by the Xposed module) live in the LSPosed remote
  *    preferences exposed through [App.service]. They are only available while the
  *    XposedService is bound; when it isn't, reads fall back to defaults and writes
- *    are dropped (the UI is gated behind a bound service anyway).
+ *    wait briefly for the service before reporting that the write was skipped.
  *  - Manager-only settings (language, favorites, broadcast control) live in a local
  *    [SharedPreferences] file so they are always available, including at startup and
  *    when the module is disabled.
@@ -90,6 +94,10 @@ import kotlinx.coroutines.flow.flowOf
 class PreferencesRepository(context: Context) {
     private val tag = "PreferencesRepository"
 
+    private companion object {
+        const val REMOTE_PREFS_BIND_TIMEOUT_MS = 3_000L
+    }
+
     private val gson = Gson()
 
     private val localPrefs: SharedPreferences =
@@ -97,6 +105,16 @@ class PreferencesRepository(context: Context) {
 
     private fun remotePrefs(): SharedPreferences? =
         App.service?.getRemotePreferences(REMOTE_PREFS_GROUP)
+
+    private suspend fun remotePrefsWhenAvailable(): SharedPreferences? {
+        remotePrefs()?.let { return it }
+
+        val service = withTimeoutOrNull(REMOTE_PREFS_BIND_TIMEOUT_MS) {
+            App.serviceState.first { it != null }
+        } ?: return null
+
+        return service.getRemotePreferences(REMOTE_PREFS_GROUP)
+    }
 
     // region Flow helpers
 
@@ -131,13 +149,20 @@ class PreferencesRepository(context: Context) {
 
     // region Write helpers
 
-    private inline fun editRemote(action: SharedPreferences.Editor.() -> Unit) {
-        val prefs = remotePrefs()
+    private suspend fun editRemote(action: SharedPreferences.Editor.() -> Unit) {
+        val prefs = remotePrefsWhenAvailable()
         if (prefs == null) {
             Log.w(tag, "Remote preferences unavailable (service not bound); write skipped")
             return
         }
-        prefs.edit(action = action)
+        val committed = withContext(Dispatchers.IO) {
+            val editor = prefs.edit()
+            editor.action()
+            editor.commit()
+        }
+        if (!committed) {
+            Log.w(tag, "Remote preferences commit failed")
+        }
     }
 
     private inline fun editLocal(action: SharedPreferences.Editor.() -> Unit) {
@@ -154,7 +179,15 @@ class PreferencesRepository(context: Context) {
 
     // region Is Playing (remote)
     fun getIsPlayingFlow(): Flow<Boolean> = remoteFlow(KEY_IS_PLAYING, false) { it.getBoolean(KEY_IS_PLAYING, false) }
-    suspend fun saveIsPlaying(isPlaying: Boolean) = editRemote { putBoolean(KEY_IS_PLAYING, isPlaying) }
+    suspend fun saveIsPlaying(isPlaying: Boolean) {
+        editRemote {
+            if (isPlaying) {
+                putBoolean(KEY_IS_PLAYING, true)
+            } else {
+                remove(KEY_IS_PLAYING)
+            }
+        }
+    }
     fun getIsPlaying(): Boolean = remotePrefs()?.getBoolean(KEY_IS_PLAYING, false) ?: false
     // endregion
 

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapDialogs.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapDialogs.kt
@@ -2,14 +2,17 @@ package com.noobexon.xposedfakelocation.manager.ui.map
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -18,6 +21,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.noobexon.xposedfakelocation.R
+import com.noobexon.xposedfakelocation.data.MAX_ROUTE_WAYPOINTS
+import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
 
 /**
  * Stateless dialog that lets the user jump the camera (and spoof marker) to an arbitrary
@@ -170,6 +175,81 @@ fun AddToFavoritesDialog(
         dismissButton = {
             TextButton(onClick = onDismissRequest) {
                 Text(stringResource(R.string.action_cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun RouteDialog(
+    waypoints: List<RouteWaypoint>,
+    isLoopEnabled: Boolean,
+    isRouteMoving: Boolean,
+    onLoopChange: (Boolean) -> Unit,
+    onClearRoute: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(stringResource(R.string.map_custom_route)) },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(R.string.route_point_count, waypoints.size, MAX_ROUTE_WAYPOINTS),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                if (waypoints.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.route_empty),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                } else {
+                    waypoints.forEachIndexed { index, waypoint ->
+                        Text(
+                            text = stringResource(
+                                R.string.route_point_format,
+                                index + 1,
+                                waypoint.latitude,
+                                waypoint.longitude
+                            ),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = stringResource(R.string.route_loop),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Switch(checked = isLoopEnabled, onCheckedChange = onLoopChange)
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.route_speed_hint),
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(
+                        if (isRouteMoving) R.string.route_status_moving else R.string.route_status_idle
+                    ),
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(R.string.action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onClearRoute, enabled = waypoints.isNotEmpty()) {
+                Text(stringResource(R.string.route_clear))
             }
         }
     )

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapModel.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapModel.kt
@@ -2,6 +2,8 @@ package com.noobexon.xposedfakelocation.manager.ui.map
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
+import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
+import com.noobexon.xposedfakelocation.data.MAX_ROUTE_WAYPOINTS
 import org.osmdroid.util.GeoPoint
 
 /**
@@ -61,8 +63,21 @@ data class MapUiState(
     val isAddToFavoritesDialogVisible: Boolean = false,
     val goToPointState: GoToPointInputState = GoToPointInputState(),
     val hasResolvedInitialLocation: Boolean = false,
+    val routeWaypoints: List<RouteWaypoint> = emptyList(),
+    val isRouteLoopEnabled: Boolean = false,
+    val isRouteDialogVisible: Boolean = false,
+    val isRouteMoving: Boolean = false,
 ) {
     /** `true` when the FAB should be interactive, i.e. a spoof target has been placed on the map. */
     val isFabClickable: Boolean
+        get() = lastClickedLocation != null || canPlayRoute
+
+    val canAddRouteWaypoint: Boolean
+        get() = lastClickedLocation != null && !isRouteMoving && routeWaypoints.size < MAX_ROUTE_WAYPOINTS
+
+    val canPlayRoute: Boolean
+        get() = routeWaypoints.size >= 2
+
+    val canClearLocation: Boolean
         get() = lastClickedLocation != null
 }

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapModel.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapModel.kt
@@ -68,7 +68,7 @@ data class MapUiState(
     val isRouteDialogVisible: Boolean = false,
     val isRouteMoving: Boolean = false,
 ) {
-    /** `true` when the FAB should be interactive, i.e. a spoof target has been placed on the map. */
+    /** `true` when the FAB can start/stop spoofing or route playback. */
     val isFabClickable: Boolean
         get() = lastClickedLocation != null || canPlayRoute
 

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.LocationSearching
@@ -78,11 +79,13 @@ fun MapScreen(
     val isFabClickable = uiState.isFabClickable
     val showGoToPointDialog = uiState.isGoToPointDialogVisible
     val showAddToFavoritesDialog = uiState.isAddToFavoritesDialogVisible
+    val showRouteDialog = uiState.isRouteDialogVisible
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     var showOptionsMenu by remember { mutableStateOf(false) }
     val fakeLocationSet = stringResource(R.string.toast_fake_location_set)
     val fakeLocationUnset = stringResource(R.string.toast_unset_fake_location)
+    val routePointAdded = stringResource(R.string.toast_route_point_added)
 
     BackHandler(enabled = drawerState.isOpen) {
         scope.launch { drawerState.close() }
@@ -173,6 +176,35 @@ fun MapScreen(
                             DropdownMenuItem(
                                 leadingIcon = {
                                     Icon(
+                                        imageVector = Icons.Default.Add,
+                                        contentDescription = stringResource(R.string.map_add_route_point)
+                                    )
+                                },
+                                text = { Text(stringResource(R.string.map_add_route_point)) },
+                                onClick = {
+                                    showOptionsMenu = false
+                                    if (mapViewModel.addCurrentLocationToRoute()) {
+                                        Toast.makeText(context, routePointAdded, Toast.LENGTH_SHORT).show()
+                                    }
+                                },
+                                enabled = uiState.canAddRouteWaypoint
+                            )
+                            DropdownMenuItem(
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.LocationSearching,
+                                        contentDescription = stringResource(R.string.map_custom_route)
+                                    )
+                                },
+                                text = { Text(stringResource(R.string.map_custom_route)) },
+                                onClick = {
+                                    showOptionsMenu = false
+                                    mapViewModel.showRouteDialog()
+                                }
+                            )
+                            DropdownMenuItem(
+                                leadingIcon = {
+                                    Icon(
                                         imageVector = Icons.Default.Clear,
                                         contentDescription = stringResource(R.string.map_clear_location)
                                     )
@@ -182,7 +214,7 @@ fun MapScreen(
                                     showOptionsMenu = false
                                     mapViewModel.updateClickedLocation(null)
                                 },
-                                enabled = isFabClickable
+                                enabled = uiState.canClearLocation
                             )
                         }
                     }
@@ -283,6 +315,17 @@ fun MapScreen(
                 onLongitudeChange = mapViewModel::onFavoriteLongitudeChange,
                 onConfirm = mapViewModel::confirmAddFavorite,
                 onDismissRequest = mapViewModel::hideAddToFavoritesDialog,
+            )
+        }
+
+        if (showRouteDialog) {
+            RouteDialog(
+                waypoints = uiState.routeWaypoints,
+                isLoopEnabled = uiState.isRouteLoopEnabled,
+                isRouteMoving = uiState.isRouteMoving,
+                onLoopChange = mapViewModel::setRouteLoopEnabled,
+                onClearRoute = mapViewModel::clearRoute,
+                onDismissRequest = mapViewModel::hideRouteDialog,
             )
         }
     }

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapViewModel.kt
@@ -5,17 +5,26 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.noobexon.xposedfakelocation.R
+import com.noobexon.xposedfakelocation.data.DEFAULT_ROUTE_SPEED_MPS
+import com.noobexon.xposedfakelocation.data.MAX_ROUTE_WAYPOINTS
+import com.noobexon.xposedfakelocation.data.ROUTE_TICK_INTERVAL_MS
 import com.noobexon.xposedfakelocation.data.model.FavoriteLocation
+import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
 import com.noobexon.xposedfakelocation.data.repository.PreferencesRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.osmdroid.util.GeoPoint
+import kotlin.math.max
 
 /** Valid latitude values accepted by the "Go to point" and "Add to favorites" dialogs. */
 private val LATITUDE_RANGE = -90.0..90.0
@@ -45,6 +54,7 @@ private val LONGITUDE_RANGE = -180.0..180.0
  */
 class MapViewModel(application: Application) : AndroidViewModel(application) {
     private val preferencesRepository = PreferencesRepository(application)
+    private var routeJob: Job? = null
 
     private val _uiState = MutableStateFlow(
         MapUiState(mapZoom = preferencesRepository.getMapZoom())
@@ -78,6 +88,7 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             preferencesRepository.getIsPlayingFlow().collect { isPlaying ->
                 _uiState.update { it.copy(isPlaying = isPlaying) }
+                if (!isPlaying) stopRoutePlayback()
             }
         }
 
@@ -85,6 +96,20 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
             preferencesRepository.getLastClickedLocationFlow().collect { location ->
                 val geoPoint = location?.let { GeoPoint(it.latitude, it.longitude) }
                 _uiState.update { it.copy(lastClickedLocation = geoPoint) }
+            }
+        }
+
+        viewModelScope.launch {
+            preferencesRepository.getRouteWaypointsFlow().collect { waypoints ->
+                _uiState.update { it.copy(routeWaypoints = waypoints) }
+                if (_uiState.value.isPlaying) restartRoutePlaybackIfAvailable()
+            }
+        }
+
+        viewModelScope.launch {
+            preferencesRepository.getRouteLoopEnabledFlow().collect { enabled ->
+                _uiState.update { it.copy(isRouteLoopEnabled = enabled) }
+                if (_uiState.value.isPlaying) restartRoutePlaybackIfAvailable()
             }
         }
     }
@@ -101,6 +126,11 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
 
         viewModelScope.launch {
             preferencesRepository.saveIsPlaying(currentIsPlaying)
+            if (currentIsPlaying) {
+                restartRoutePlaybackIfAvailable()
+            } else {
+                stopRoutePlayback()
+            }
         }
     }
 
@@ -129,6 +159,42 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
             geoPoint?.let {
                 preferencesRepository.saveLastClickedLocation(it.latitude, it.longitude)
             } ?: preferencesRepository.clearLastClickedLocation()
+        }
+    }
+
+    fun showRouteDialog() {
+        _uiState.update { it.copy(isRouteDialogVisible = true) }
+    }
+
+    fun hideRouteDialog() {
+        _uiState.update { it.copy(isRouteDialogVisible = false) }
+    }
+
+    fun addCurrentLocationToRoute(): Boolean {
+        val state = _uiState.value
+        val marker = state.lastClickedLocation ?: return false
+        if (state.isRouteMoving || state.routeWaypoints.size >= MAX_ROUTE_WAYPOINTS) return false
+        val currentWaypoints = state.routeWaypoints
+        val updated = currentWaypoints + RouteWaypoint(marker.latitude, marker.longitude)
+        _uiState.update { it.copy(routeWaypoints = updated) }
+        viewModelScope.launch {
+            preferencesRepository.saveRouteWaypoints(updated)
+        }
+        return true
+    }
+
+    fun clearRoute() {
+        stopRoutePlayback()
+        _uiState.update { it.copy(routeWaypoints = emptyList(), isRouteMoving = false) }
+        viewModelScope.launch {
+            preferencesRepository.clearRouteWaypoints()
+        }
+    }
+
+    fun setRouteLoopEnabled(enabled: Boolean) {
+        _uiState.update { it.copy(isRouteLoopEnabled = enabled) }
+        viewModelScope.launch {
+            preferencesRepository.saveRouteLoopEnabled(enabled)
         }
     }
 
@@ -404,5 +470,81 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
     ): Int? {
         val value = input.toDoubleOrNull()
         return if (value == null || value !in range) errorMessageRes else null
+    }
+
+    private fun restartRoutePlaybackIfAvailable() {
+        stopRoutePlayback()
+        val state = _uiState.value
+        if (!state.isPlaying || state.routeWaypoints.size < 2) return
+        routeJob = viewModelScope.launch {
+            runRoutePlayback(
+                waypoints = state.routeWaypoints,
+                loop = state.isRouteLoopEnabled
+            )
+        }
+    }
+
+    private fun stopRoutePlayback() {
+        routeJob?.cancel()
+        routeJob = null
+        _uiState.update { it.copy(isRouteMoving = false) }
+    }
+
+    private suspend fun runRoutePlayback(waypoints: List<RouteWaypoint>, loop: Boolean) {
+        if (waypoints.size < 2) return
+
+        _uiState.update { it.copy(isRouteMoving = true) }
+        var currentIndex = 0
+        var direction = 1
+
+        while (currentCoroutineContext().isActive) {
+            val nextIndex = currentIndex + direction
+            if (nextIndex !in waypoints.indices) {
+                if (!loop) break
+                direction *= -1
+                continue
+            }
+
+            moveAlongSegment(waypoints[currentIndex], waypoints[nextIndex])
+            currentIndex = nextIndex
+        }
+
+        _uiState.update { it.copy(isRouteMoving = false) }
+    }
+
+    private suspend fun moveAlongSegment(start: RouteWaypoint, end: RouteWaypoint) {
+        val speed = routeSpeedMetersPerSecond()
+        val distanceMeters = RoutePlaybackCalculator.distanceBetween(start, end)
+        val durationMs = max(ROUTE_TICK_INTERVAL_MS, ((distanceMeters / speed) * 1000).toLong())
+        val startedAt = System.currentTimeMillis()
+
+        while (currentCoroutineContext().isActive) {
+            val elapsedMs = System.currentTimeMillis() - startedAt
+            val progress = (elapsedMs.toDouble() / durationMs).coerceIn(0.0, 1.0)
+            val latitude = RoutePlaybackCalculator.interpolate(start.latitude, end.latitude, progress)
+            val longitude = RoutePlaybackCalculator.interpolate(start.longitude, end.longitude, progress)
+            publishRouteLocation(latitude, longitude)
+            if (progress >= 1.0) break
+            delay(ROUTE_TICK_INTERVAL_MS)
+        }
+    }
+
+    private suspend fun publishRouteLocation(latitude: Double, longitude: Double) {
+        _uiState.update { it.copy(lastClickedLocation = GeoPoint(latitude, longitude)) }
+        preferencesRepository.saveLastClickedLocation(latitude, longitude)
+    }
+
+    private fun routeSpeedMetersPerSecond(): Float {
+        val speed = if (preferencesRepository.getUseSpeed()) {
+            preferencesRepository.getSpeed()
+        } else {
+            DEFAULT_ROUTE_SPEED_MPS
+        }
+        return speed.takeIf { it > 0f } ?: DEFAULT_ROUTE_SPEED_MPS
+    }
+
+    override fun onCleared() {
+        stopRoutePlayback()
+        super.onCleared()
     }
 }

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/MapViewModel.kt
@@ -522,7 +522,7 @@ class MapViewModel(application: Application) : AndroidViewModel(application) {
             val elapsedMs = System.currentTimeMillis() - startedAt
             val progress = (elapsedMs.toDouble() / durationMs).coerceIn(0.0, 1.0)
             val latitude = RoutePlaybackCalculator.interpolate(start.latitude, end.latitude, progress)
-            val longitude = RoutePlaybackCalculator.interpolate(start.longitude, end.longitude, progress)
+            val longitude = RoutePlaybackCalculator.interpolateLongitude(start.longitude, end.longitude, progress)
             publishRouteLocation(latitude, longitude)
             if (progress >= 1.0) break
             delay(ROUTE_TICK_INTERVAL_MS)

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculator.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculator.kt
@@ -13,6 +13,12 @@ internal object RoutePlaybackCalculator {
         return start + (end - start) * clampedProgress
     }
 
+    fun interpolateLongitude(start: Double, end: Double, progress: Double): Double {
+        val clampedProgress = progress.coerceIn(0.0, 1.0)
+        val delta = normalizeLongitude(end - start)
+        return normalizeLongitude(start + delta * clampedProgress)
+    }
+
     fun distanceBetween(start: RouteWaypoint, end: RouteWaypoint): Double {
         val startLat = Math.toRadians(start.latitude)
         val endLat = Math.toRadians(end.latitude)
@@ -22,5 +28,11 @@ internal object RoutePlaybackCalculator {
             cos(startLat) * cos(endLat) * sin(deltaLon / 2) * sin(deltaLon / 2)
         val c = 2 * asin(sqrt(a.coerceIn(0.0, 1.0)))
         return RADIUS_EARTH * c
+    }
+
+    private fun normalizeLongitude(longitude: Double): Double {
+        var normalized = (longitude + 180.0) % 360.0
+        if (normalized < 0.0) normalized += 360.0
+        return normalized - 180.0
     }
 }

--- a/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculator.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculator.kt
@@ -1,0 +1,26 @@
+package com.noobexon.xposedfakelocation.manager.ui.map
+
+import com.noobexon.xposedfakelocation.data.RADIUS_EARTH
+import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+internal object RoutePlaybackCalculator {
+    fun interpolate(start: Double, end: Double, progress: Double): Double {
+        val clampedProgress = progress.coerceIn(0.0, 1.0)
+        return start + (end - start) * clampedProgress
+    }
+
+    fun distanceBetween(start: RouteWaypoint, end: RouteWaypoint): Double {
+        val startLat = Math.toRadians(start.latitude)
+        val endLat = Math.toRadians(end.latitude)
+        val deltaLat = Math.toRadians(end.latitude - start.latitude)
+        val deltaLon = Math.toRadians(end.longitude - start.longitude)
+        val a = sin(deltaLat / 2) * sin(deltaLat / 2) +
+            cos(startLat) * cos(endLat) * sin(deltaLon / 2) * sin(deltaLon / 2)
+        val c = 2 * asin(sqrt(a.coerceIn(0.0, 1.0)))
+        return RADIUS_EARTH * c
+    }
+}

--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/ModuleEntry.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/ModuleEntry.kt
@@ -10,6 +10,7 @@ import com.noobexon.xposedfakelocation.xposed.hooks.PhoneServicesHooks
 import com.noobexon.xposedfakelocation.xposed.hooks.SystemServicesHooks
 import com.noobexon.xposedfakelocation.xposed.utils.LocationUtil
 import com.noobexon.xposedfakelocation.xposed.utils.PreferencesUtil
+import io.github.libxposed.api.XposedInterface
 import io.github.libxposed.api.XposedModule
 import io.github.libxposed.api.XposedModuleInterface.ModuleLoadedParam
 import io.github.libxposed.api.XposedModuleInterface.PackageLoadedParam
@@ -28,7 +29,14 @@ private const val TAG = "[ModuleEntry]"
  *   - `com.android.phone` → [PhoneServicesHooks] only (telephony cell/Wi-Fi spoofing).
  *   - `android` (system_server, when opted in) → [SystemServicesHooks].
  */
-class ModuleEntry : XposedModule() {
+class ModuleEntry() : XposedModule() {
+    private var framework: XposedInterface = this
+
+    constructor(module: XposedInterface, param: ModuleLoadedParam) : this() {
+        framework = module
+        onModuleLoaded(param)
+    }
+
     
     /**
      * Called once when the module is first loaded into a process.
@@ -36,7 +44,7 @@ class ModuleEntry : XposedModule() {
      * log calls are routed through the libxposed logging channel.
      */
     override fun onModuleLoaded(param: ModuleLoadedParam) {
-        log(Log.INFO, TAG, "onModuleLoaded: ${param.processName}")
+        framework.log(Log.INFO, TAG, "onModuleLoaded: ${param.processName}")
         initLoggers()
     }
 
@@ -46,7 +54,7 @@ class ModuleEntry : XposedModule() {
      * hooks fire.
      */
     override fun onPackageLoaded(param: PackageLoadedParam) {
-        log(Log.INFO, TAG, "onPackageLoaded: ${param.packageName}")
+        framework.log(Log.INFO, TAG, "onPackageLoaded: ${param.packageName}")
         initRemotePreferences()
     }
 
@@ -60,7 +68,7 @@ class ModuleEntry : XposedModule() {
      * Only the first package in the process is processed ([PackageReadyParam.isFirstPackage]).
      */
     override fun onPackageReady(param: PackageReadyParam) {
-        log(Log.INFO, TAG, "onPackageReady: ${param.packageName}")
+        framework.log(Log.INFO, TAG, "onPackageReady: ${param.packageName}")
 
         if (!param.isFirstPackage) return // Run per-package setup only once.
 
@@ -82,37 +90,37 @@ class ModuleEntry : XposedModule() {
      * deep system-level location interception. Installs [SystemServicesHooks].
      */
     override fun onSystemServerStarting(param: SystemServerStartingParam) {
-        log(Log.INFO, TAG, "onSystemServerStarting: ${param.classLoader}")
+        framework.log(Log.INFO, TAG, "onSystemServerStarting: ${param.classLoader}")
         initRemotePreferences()
         initSystemHooks(param.classLoader)
     }
 
     /** Routes [LocationUtil] and [PreferencesUtil] log calls through the libxposed logger. */
     private fun initLoggers() {
-        val logger: (Int, String, String) -> Unit = { priority, tag, message -> log(priority, tag, message) }
+        val logger: (Int, String, String) -> Unit = { priority, tag, message -> framework.log(priority, tag, message) }
         LocationUtil.logger = logger
         PreferencesUtil.logger = logger
     }
 
     /** Fetches and initializes the LSPosed remote [SharedPreferences] used by hook-side utils. */
     private fun initRemotePreferences() {
-        PreferencesUtil.init(getRemotePreferences(REMOTE_PREFS_GROUP))
+        PreferencesUtil.init(framework.getRemotePreferences(REMOTE_PREFS_GROUP))
     }
 
     /** Installs [LocationApiHooks] and [LocationManagerApiHooks] into the target app process. */
     private fun initHooks(classLoader: ClassLoader) {
-        LocationApiHooks(this, classLoader).init()
-        LocationManagerApiHooks(this, classLoader).init()
+        LocationApiHooks(framework, classLoader).init()
+        LocationManagerApiHooks(framework, classLoader).init()
     }
 
     /** Installs [PhoneServicesHooks] into the `com.android.phone` process. */
     private fun initPhoneServiceHooks(classLoader: ClassLoader) {
-        PhoneServicesHooks(this, classLoader).init()
+        PhoneServicesHooks(framework, classLoader).init()
     }
 
     /** Installs [SystemServicesHooks] into the system_server process. */
     private fun initSystemHooks(classLoader: ClassLoader) {
-        SystemServicesHooks(this, classLoader).init()
+        SystemServicesHooks(framework, classLoader).init()
     }
 
     /**
@@ -122,13 +130,13 @@ class ModuleEntry : XposedModule() {
     private fun showActiveToast(param: PackageReadyParam) {
         val clazz = Class.forName("android.app.Instrumentation", false, param.classLoader)
         val method = clazz.getDeclaredMethod("callApplicationOnCreate", Application::class.java)
-        hook(method).intercept { chain ->
+        framework.hook(method).intercept { chain ->
             val result = chain.proceed()
             runCatching {
                 val context = (chain.getArg(0) as Application).applicationContext
-                log(Log.INFO, TAG, "Target App's context has been acquired (${param.packageName}).")
+                framework.log(Log.INFO, TAG, "Target App's context has been acquired (${param.packageName}).")
                 Toast.makeText(context, "Fake Location Is Active!", Toast.LENGTH_SHORT).show()
-            }.onFailure { log(Log.ERROR, TAG, "Toast/context failed - ${it.message}") }
+            }.onFailure { framework.log(Log.ERROR, TAG, "Toast/context failed - ${it.message}") }
             result
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -127,13 +127,24 @@
 
     <string name="map_go_to_point">前往坐标点</string>
     <string name="map_add_to_favorites">添加到收藏</string>
+    <string name="map_add_route_point">添加路线点</string>
+    <string name="map_custom_route">自定义路线</string>
     <string name="map_add_to_templates">添加到模板</string>
     <string name="map_update_template_location">更新模板位置</string>
     <string name="map_clear_location">清除位置</string>
     <string name="toast_fake_location_set">已设置虚拟位置</string>
     <string name="toast_unset_fake_location">已取消虚拟位置</string>
+    <string name="toast_route_point_added">已添加路线点</string>
     <string name="toast_user_location_not_available">用户位置不可用</string>
     <string name="map_updating">正在更新地图…</string>
+    <string name="route_point_count">路线点：%1$d/%2$d</string>
+    <string name="route_empty">先在地图上放置标记，再使用“添加路线点”创建路线。</string>
+    <string name="route_point_format">点 %1$d：%2$.6f，%3$.6f</string>
+    <string name="route_loop">循环路线</string>
+    <string name="route_speed_hint">路线播放会优先使用“自定义速度”设置；未启用时使用 1.4 m/s。</string>
+    <string name="route_status_idle">设置至少两个点后，开启虚拟定位时会启动路线播放。</string>
+    <string name="route_status_moving">路线正在播放。</string>
+    <string name="route_clear">清空路线</string>
 
     <string name="field_name">名称</string>
     <string name="field_description">描述（可选）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,13 +129,24 @@
 
     <string name="map_go_to_point">Go to Point</string>
     <string name="map_add_to_favorites">Add to Favorites</string>
+    <string name="map_add_route_point">Add Route Point</string>
+    <string name="map_custom_route">Custom Route</string>
     <string name="map_add_to_templates">Add to Templates</string>
     <string name="map_update_template_location">Update Template Location</string>
     <string name="map_clear_location">Clear Location</string>
     <string name="toast_fake_location_set">Fake Location Set</string>
     <string name="toast_unset_fake_location">Unset Fake Location</string>
+    <string name="toast_route_point_added">Route point added</string>
     <string name="toast_user_location_not_available">User location not available</string>
     <string name="map_updating">Updating Map…</string>
+    <string name="route_point_count">Route points: %1$d/%2$d</string>
+    <string name="route_empty">Place a marker on the map, then use Add Route Point to build a route.</string>
+    <string name="route_point_format">Point %1$d: %2$.6f, %3$.6f</string>
+    <string name="route_loop">Loop route</string>
+    <string name="route_speed_hint">Route playback uses the Custom Speed setting when enabled; otherwise it uses 1.4 m/s.</string>
+    <string name="route_status_idle">Route playback starts when spoofing is turned on and at least two points are set.</string>
+    <string name="route_status_moving">Route playback is running.</string>
+    <string name="route_clear">Clear route</string>
 
     <string name="field_name">Name</string>
     <string name="field_description">Description (optional)</string>

--- a/app/src/test/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculatorTest.kt
+++ b/app/src/test/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculatorTest.kt
@@ -1,0 +1,48 @@
+package com.noobexon.xposedfakelocation.manager.ui.map
+
+import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RoutePlaybackCalculatorTest {
+    @Test
+    fun interpolate_clampsProgressBelowZero() {
+        val result = RoutePlaybackCalculator.interpolate(10.0, 20.0, -1.0)
+
+        assertEquals(10.0, result, 0.0)
+    }
+
+    @Test
+    fun interpolate_clampsProgressAboveOne() {
+        val result = RoutePlaybackCalculator.interpolate(10.0, 20.0, 2.0)
+
+        assertEquals(20.0, result, 0.0)
+    }
+
+    @Test
+    fun interpolate_returnsPointBetweenCoordinates() {
+        val result = RoutePlaybackCalculator.interpolate(10.0, 20.0, 0.25)
+
+        assertEquals(12.5, result, 0.0)
+    }
+
+    @Test
+    fun distanceBetween_returnsZeroForSameWaypoint() {
+        val point = RouteWaypoint(latitude = 1.0, longitude = 2.0)
+
+        val result = RoutePlaybackCalculator.distanceBetween(point, point)
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun distanceBetween_returnsApproximateDistanceForOneDegreeAtEquator() {
+        val start = RouteWaypoint(latitude = 0.0, longitude = 0.0)
+        val end = RouteWaypoint(latitude = 0.0, longitude = 1.0)
+
+        val result = RoutePlaybackCalculator.distanceBetween(start, end)
+
+        assertTrue(result in 111_000.0..112_000.0)
+    }
+}

--- a/app/src/test/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculatorTest.kt
+++ b/app/src/test/java/com/noobexon/xposedfakelocation/manager/ui/map/RoutePlaybackCalculatorTest.kt
@@ -4,6 +4,7 @@ import com.noobexon.xposedfakelocation.data.model.RouteWaypoint
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.math.abs
 
 class RoutePlaybackCalculatorTest {
     @Test
@@ -25,6 +26,20 @@ class RoutePlaybackCalculatorTest {
         val result = RoutePlaybackCalculator.interpolate(10.0, 20.0, 0.25)
 
         assertEquals(12.5, result, 0.0)
+    }
+
+    @Test
+    fun interpolateLongitude_usesShortestPathAcrossDateLineEastbound() {
+        val result = RoutePlaybackCalculator.interpolateLongitude(179.9, -179.9, 0.5)
+
+        assertEquals(180.0, abs(result), 0.0001)
+    }
+
+    @Test
+    fun interpolateLongitude_usesShortestPathAcrossDateLineWestbound() {
+        val result = RoutePlaybackCalculator.interpolateLongitude(-179.9, 179.9, 0.5)
+
+        assertEquals(180.0, abs(result), 0.0001)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Addresses #43 with a minimal first-pass custom route implementation.
- Add a local custom route model with up to 4 route points.
- Add map actions to save route points, view/clear the route, and toggle loop playback.
- Play routes by periodically updating the existing spoof target location, so the hook side can keep reading the current preference value.
- Reuse the existing Custom Speed setting when enabled, with a walking-speed fallback.
- Wait briefly for LSPosed remote preferences before manager writes, commit those writes on an IO dispatcher, and remove `is_playing` when spoofing stops.
- Add a libxposed/Vector-compatible module constructor so the target-app hook path can load through the `(XposedInterface, ModuleLoadedParam)` entry point.
- Add unit coverage for route interpolation and distance calculations.

## Notes

This is intentionally a small first pass for #43. It does not add GPX import, road-following navigation, background route playback, or a full route editor. Route playback currently interpolates directly between saved waypoints.

## Testing

- `./gradlew.bat :app:compileDebugKotlin :app:assembleDebug --no-daemon --console=plain`
- `./gradlew.bat :app:testDebugUnitTest --no-daemon --console=plain`
- `git diff --check`
- API 30 emulator smoke: installed debug APK, launched `MainActivity`, opened the map overflow menu, added 2 route points, and started route playback.
- Root_API30 / Android 11 / Magisk 26.4 / Vector v2.0 emulator smoke: from clean app data, granted location permission, added 2 distinct route points through the map overflow, confirmed `Custom Route` showed `Route points: 2/4`, started playback from the FAB, confirmed the FAB changed to `Stop`, reopened `Custom Route`, and confirmed `Route playback is running.`
- Root_API30 remote-preferences smoke: Vector configs DB contained `is_playing=true` and `last_clicked_location` for the active route point after playback started.
- Root_API30 / Android 11 / Magisk 26.4 / Vector v2.0 (3043, API 101) target-app hook smoke: scoped a local probe app, set `is_playing=true` and `last_clicked_location={"latitude":37.423,"longitude":-122.084}`, and confirmed direct `Location`, `getLastKnownLocation(gps/network/passive)`, and `requestLocationUpdates(gps)` all returned `37.423, -122.084` in the probe process.
- Android 16 rooted OnePlus PJD110 manager smoke: installed the debug APK via root `pm install`, enabled/launched the manager, added 2 route points, started route playback, rebooted, and confirmed LSPosed sent the module binder back to the manager.
- Android 16 remote-preferences smoke after reboot: route playback set `is_playing=true`, continuously updated `last_clicked_location`, mirrored the selected target app list, and removed `is_playing` after spoofing stopped.
- Android 16 rooted OnePlus PJD110 target-app hook smoke: scoped a local probe app, set `is_playing=true`, configured the probe package as the target app, and confirmed direct `Location` plus `getLastKnownLocation(gps/network/passive)` returned `37.423, -122.084`.
- Fresh API 30 emulator permission-gated smoke: after clearing app data, granted location permission, launched `MainActivity`, confirmed the map overflow includes `Add Route Point` and `Custom Route`, and saw no `FATAL EXCEPTION` in recent logcat. This does not count as route playback or hook-side verification.

`./gradlew.bat :app:lintDebug --no-daemon --console=plain` currently fails on the upstream `master` baseline too with an Android lint crash in `androidx.lifecycle.lint.NonNullableMutableLiveDataDetector` while analyzing `PrefrencesRepository.kt`:

```text
Found class org.jetbrains.kotlin.analysis.api.resolution.KaCallableMemberCall, but interface was expected
```

Earlier Root_API30 hook-side testing with Vector v2.0 (3021) reported a `ModuleEntry` constructor mismatch. The passing hook-side evidence above uses the local constructor compatibility patch plus Vector v2.0 (3043) / API 101.
