### PR TITLE
fix: system_server hooks return (0,0) instead of chosen fake location

### DIFF
--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/hooks/LocationManagerApiHooks.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/hooks/LocationManagerApiHooks.kt
@@ -30,10 +30,9 @@ class LocationManagerApiHooks(
     /**
      * Resolves [android.location.LocationManager] and hooks `getLastKnownLocation(provider)`.
      *
-     * When [PreferencesUtil.getIsPlaying] is `true`, calls [LocationUtil.updateLocation] to
-     * refresh the current spoofed state, then returns a fake [Location] via
-     * [LocationUtil.createFakeLocation] using the requested provider. Otherwise, the original
-     * result is passed through unchanged.
+     * When [PreferencesUtil.getIsPlaying] is `true`, returns a fake [Location] via
+     * [LocationUtil.createFakeLocation] using the requested provider (which refreshes the
+     * spoofed state internally). Otherwise, the original result is passed through unchanged.
      */
     private fun hookLocationManager() {
         runCatching {
@@ -47,7 +46,6 @@ class LocationManagerApiHooks(
                 module.log(Log.INFO, tag, "\tRequested data from: $provider")
                 module.log(Log.INFO, tag, "\tOriginal location: $original")
                 if (PreferencesUtil.getIsPlaying() == true) {
-                    LocationUtil.updateLocation()
                     val fakeLocation = LocationUtil.createFakeLocation(provider = provider)
                     module.log(Log.INFO, tag, "\tModified location: $fakeLocation")
                     fakeLocation

--- a/app/src/main/java/com/noobexon/xposedfakelocation/xposed/utils/LocationUtil.kt
+++ b/app/src/main/java/com/noobexon/xposedfakelocation/xposed/utils/LocationUtil.kt
@@ -77,6 +77,11 @@ object LocationUtil {
     /**
      * Builds a [Location] object populated with the current spoofed field values.
      *
+     * [updateLocation] is invoked first so the spoofed fields always reflect the latest
+     * preferences, regardless of which hook path calls this method. Without this, callers
+     * that skip [updateLocation] (e.g. the system_server hooks) build a location from the
+     * initial `0.0` coordinates.
+     *
      * If [originalLocation] is provided its metadata (time, bearing, elapsed realtime, etc.)
      * is preserved; otherwise a fresh [Location] is created with a slightly backdated timestamp
      * to satisfy recency checks in some apps.
@@ -92,6 +97,8 @@ object LocationUtil {
      */
     @Synchronized
     fun createFakeLocation(originalLocation: Location? = null, provider: String = LocationManager.GPS_PROVIDER): Location {
+        updateLocation()
+
         val fakeLocation = if (originalLocation == null) {
             Location(provider).apply {
                 time = System.currentTimeMillis() - 300


### PR DESCRIPTION
## Bug

All 8 call sites of `LocationUtil.createFakeLocation()` in `SystemServicesHooks` read `latitude`/`longitude` without first calling `updateLocation()`. Because those fields default to `0.0` and are only populated by `updateLocation()`, the system_server path always returns the null-island coordinates (0°N 0°E) instead of the user's chosen fake location.

Affected hooks:
- `hookLastLocation` → `getLastLocation`
- `interceptOnReportLocation` → `onReportLocation`
- `interceptCallLocationChanged` → `callLocationChangedLocked`
- `replaceLocationLikeResult` → MIUI blurry location
- `hookGeofence` (indirectly, via blocked geofence registration)

## Root cause

`LocationApiHooks` and `LocationManagerApiHooks` (app-process hooks) call `updateLocation()` explicitly before reading `LocationUtil` fields. `SystemServicesHooks` (system_server hooks) call `createFakeLocation()` directly without refreshing state first, so the singleton's fields stay at their initial `0.0` values.

## Fix

Move `updateLocation()` into `LocationUtil.createFakeLocation()` so every caller — regardless of hook path — always reads fresh preferences before building the fake `Location`. This makes the invariant self-enforcing: `createFakeLocation` can never return stale coordinates.

`@Synchronized` on both methods uses the same monitor (`LocationUtil` singleton), and JVM monitors are reentrant, so the nested call is safe.

Remove the now-redundant explicit `updateLocation()` call in `LocationManagerApiHooks` and update its KDoc.

## Files changed

- `LocationUtil.kt` — add `updateLocation()` at the top of `createFakeLocation()`
- `LocationManagerApiHooks.kt` — remove redundant `updateLocation()` call, update KDoc